### PR TITLE
'Killjoy Neil' removed endless liking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -168,7 +168,7 @@ export default class Feed extends Component {
       return (<div>Loading ...</div>)
     }
 
-    var posts = posts.map((post, i) => {
+    posts = posts.map((post, i) => {
       return (
         <Post
           key={`post-${i}`}


### PR DESCRIPTION
The issue was, of course, embarrassingly stupid - `usersLiked` field is array of objects containing `firstName`, `lastName` and `_id` as specified by the server, it was being treated web-side as a simple array of `_id`'s (so `usersLiked.inclues(user._id)` obviously failed every time).
Derp.